### PR TITLE
Parameter and reponse schemas

### DIFF
--- a/fixtures/specifications/echo.yaml
+++ b/fixtures/specifications/echo.yaml
@@ -17,9 +17,7 @@ paths:
           description: Ok
           headers:
             value:
-              required: true
-              schema:
-                type: string
+              $ref: "#/components/headers/value"
           content:
             text/plain: {}
             application/octet-stream: {}
@@ -30,5 +28,10 @@ components:
       in: query
       required: true
       name: value
+      schema:
+        type: string
+  headers:
+    value:
+      required: true
       schema:
         type: string

--- a/fixtures/specifications/echo.yaml
+++ b/fixtures/specifications/echo.yaml
@@ -8,7 +8,7 @@ info:
 paths:
   /echo:
     parameters:
-      - $ref: "#/components/parameters/value"
+      - $ref: "#/components/parameters/value-parameter"
     post:
       operationId: echo
       summary: echo
@@ -17,21 +17,21 @@ paths:
           description: Ok
           headers:
             value:
-              $ref: "#/components/headers/value"
+              $ref: "#/components/headers/value-header"
           content:
             text/plain: {}
             application/octet-stream: {}
 
 components:
   parameters:
-    value:
+    value-parameter:
       in: query
       required: true
       name: value
       schema:
         type: string
   headers:
-    value:
+    value-header:
       required: true
       schema:
         type: string

--- a/fixtures/specifications/echo.yaml
+++ b/fixtures/specifications/echo.yaml
@@ -8,11 +8,7 @@ info:
 paths:
   /echo:
     parameters:
-      - in: query
-        required: true
-        name: value
-        schema:
-          type: string
+      - $ref: "#/components/parameters/value"
     post:
       operationId: echo
       summary: echo
@@ -27,3 +23,12 @@ paths:
           content:
             text/plain: {}
             application/octet-stream: {}
+
+components:
+  parameters:
+    value:
+      in: query
+      required: true
+      name: value
+      schema:
+        type: string

--- a/packages/cargo/skiffa-core/src/documents/oas30/document.rs
+++ b/packages/cargo/skiffa-core/src/documents/oas30/document.rs
@@ -604,14 +604,16 @@ impl Document {
     node: nodes::Api,
   ) -> impl Iterator<Item = Result<NodeLocation, DocumentError>> + '_ {
     iter::empty()
-      // .chain({
-      //   let location = location.clone();
-      //   node
-      //     .schema_component_pointers()
-      //     .into_iter()
-      //     .flatten()
-      //     .map(move |pointer| Ok(location.push_pointer(pointer)))
-      // })
+      .chain({
+        let location = location.clone();
+        node
+          .schema_component_pointers()
+          .into_iter()
+          .flatten()
+          .map(move |pointer| Ok(location.push_pointer(pointer)))
+      })
+      // TODO read parameter components
+      // TODO read response components
       .chain(Self::get_sub_locations_from_node_entries(
         location.clone(),
         node

--- a/packages/cargo/skiffa-core/src/documents/oas30/document.rs
+++ b/packages/cargo/skiffa-core/src/documents/oas30/document.rs
@@ -612,8 +612,16 @@ impl Document {
           .flatten()
           .map(move |pointer| Ok(location.push_pointer(pointer)))
       })
-      // TODO read parameter components
-      // TODO read response components
+      .chain(Self::get_sub_locations_from_node_entries(
+        location.clone(),
+        node.parameter_components().into_iter().flatten(),
+        |location, node| self.get_schema_locations_from_request_parameter(location, node),
+      ))
+      .chain(Self::get_sub_locations_from_node_entries(
+        location.clone(),
+        node.response_components().into_iter().flatten(),
+        |location, node| self.get_schema_locations_from_operation_result(location, node),
+      ))
       .chain(Self::get_sub_locations_from_node_entries(
         location.clone(),
         node

--- a/packages/cargo/skiffa-core/src/documents/oas30/document.rs
+++ b/packages/cargo/skiffa-core/src/documents/oas30/document.rs
@@ -619,6 +619,11 @@ impl Document {
       ))
       .chain(Self::get_sub_locations_from_node_entries(
         location.clone(),
+        node.header_components().into_iter().flatten(),
+        |location, node| self.get_schema_locations_from_response_header(location, node),
+      ))
+      .chain(Self::get_sub_locations_from_node_entries(
+        location.clone(),
         node.response_components().into_iter().flatten(),
         |location, node| self.get_schema_locations_from_operation_result(location, node),
       ))

--- a/packages/cargo/skiffa-core/src/documents/oas30/nodes/api.rs
+++ b/packages/cargo/skiffa-core/src/documents/oas30/nodes/api.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Clone)]
 pub struct Api(serde_json::Value);
@@ -72,26 +72,26 @@ impl Api {
     )
   }
 
-  // pub fn schema_component_pointers(&self) -> Option<BTreeSet<Vec<String>>> {
-  //   Some(
-  //     self
-  //       .0
-  //       .as_object()?
-  //       .get("components")?
-  //       .as_object()?
-  //       .get("schemas")?
-  //       .as_object()?
-  //       .keys()
-  //       .map(|key| {
-  //         vec![
-  //           "components".to_owned(),
-  //           "schemas".to_owned(),
-  //           key.to_owned(),
-  //         ]
-  //       })
-  //       .collect(),
-  //   )
-  // }
+  pub fn schema_component_pointers(&self) -> Option<BTreeSet<Vec<String>>> {
+    Some(
+      self
+        .0
+        .as_object()?
+        .get("components")?
+        .as_object()?
+        .get("schemas")?
+        .as_object()?
+        .keys()
+        .map(|key| {
+          vec![
+            "components".to_owned(),
+            "schemas".to_owned(),
+            key.to_owned(),
+          ]
+        })
+        .collect(),
+    )
+  }
 }
 
 impl From<serde_json::Value> for Api {

--- a/packages/cargo/skiffa-core/src/documents/oas30/nodes/api.rs
+++ b/packages/cargo/skiffa-core/src/documents/oas30/nodes/api.rs
@@ -115,6 +115,28 @@ impl Api {
     )
   }
 
+  pub fn header_components(&self) -> Option<BTreeMap<Vec<String>, ResponseHeader>> {
+    let member = "components";
+    let member_1 = "headers";
+    Some(
+      self
+        .0
+        .as_object()?
+        .get(member)?
+        .as_object()?
+        .get(member_1)?
+        .as_object()?
+        .into_iter()
+        .map(|(key, node)| {
+          (
+            vec![member.to_owned(), member_1.to_owned(), key.clone()],
+            node.clone().into(),
+          )
+        })
+        .collect(),
+    )
+  }
+
   pub fn response_components(&self) -> Option<BTreeMap<Vec<String>, OperationResult>> {
     let member = "components";
     let member_1 = "responses";

--- a/packages/cargo/skiffa-core/src/documents/oas30/nodes/api.rs
+++ b/packages/cargo/skiffa-core/src/documents/oas30/nodes/api.rs
@@ -92,6 +92,50 @@ impl Api {
         .collect(),
     )
   }
+
+  pub fn parameter_components(&self) -> Option<BTreeMap<Vec<String>, RequestParameter>> {
+    let member = "components";
+    let member_1 = "parameters";
+    Some(
+      self
+        .0
+        .as_object()?
+        .get(member)?
+        .as_object()?
+        .get(member_1)?
+        .as_object()?
+        .into_iter()
+        .map(|(key, node)| {
+          (
+            vec![member.to_owned(), member_1.to_owned(), key.clone()],
+            node.clone().into(),
+          )
+        })
+        .collect(),
+    )
+  }
+
+  pub fn response_components(&self) -> Option<BTreeMap<Vec<String>, OperationResult>> {
+    let member = "components";
+    let member_1 = "responses";
+    Some(
+      self
+        .0
+        .as_object()?
+        .get(member)?
+        .as_object()?
+        .get(member_1)?
+        .as_object()?
+        .into_iter()
+        .map(|(key, node)| {
+          (
+            vec![member.to_owned(), member_1.to_owned(), key.clone()],
+            node.clone().into(),
+          )
+        })
+        .collect(),
+    )
+  }
 }
 
 impl From<serde_json::Value> for Api {


### PR DESCRIPTION
Also discover schemas from response and parameter components. We need them to create types for them. They were missing, this results in `unknown` types.

- [x] return schema locations from schema components
- [x] return schema locations from parameter components
- [x] return schema locations from response components
- [ ] from requestBodies
- [x] from headers